### PR TITLE
Fix gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install the gem, execute:
 
     gem install elastic-site-search
 
-Or place `gem 'elastic-site-search', '~> 2.0.0` in your `Gemfile` and run `bundle install`.
+Or place `gem 'elastic-site-search', '~> 2.1.0` in your `Gemfile` and run `bundle install`.
 
 > **Note:** This client has been developed for the [Elastic Site Search](https://www.elastic.co/products/site-search/service) API endpoints only.
 

--- a/lib/elastic-site-search.rb
+++ b/lib/elastic-site-search.rb
@@ -1,0 +1,1 @@
+require 'elastic/site-search'

--- a/lib/elastic/site-search/version.rb
+++ b/lib/elastic/site-search/version.rb
@@ -1,5 +1,5 @@
 module Elastic
   module SiteSearch
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
TL;DR: This PR allows you to *not* have to require 'elastic/site-search' in order to use this client.

Rails calls `Bundler.require` on initialization.

For every gem in Gemfile, `Bundler.require` will require that
gem, by attempting to require according to the gems name.

This means that typically, gems must have a file under `lib` that
corresponds to the name of the gem.

This gem was expecting users to require with `elastic/site-search`,
which did not match the gem name. This means gems had to be
explicitly required in Rails and also is a bit of an anti-pattern for
Ruby.

This fixes that by adding the correct file, so that this gem will be
auto-required by Rails and also available via
`require elastic-site-search`, which remaining backwards compatible with
`require elastic/site-search`.

The way I tested this locally was in a separate project with a `Gemfile` including:
```
gem "elastic-site-search", path:"/Users/jasonstoltzfus/workspace/site-search-ruby"
```

Then in irb, confirming that this constant was available without a `require`
```
Bundler.require
Elastic::SiteSearch::Client
```

I also built the corresponding gem and confirmed that `require elastic-site-search` works.