### PR TITLE
Change SHA-1 to SHA-256 hashing algorithm for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To install the gem, execute:
 gem install elastic-site-search
 ```
 
-Or place `gem 'elastic-site-search', '~> 2.1.0` in your `Gemfile` and run `bundle install`.
+Or place `gem 'elastic-site-search', '~> 2.2.0` in your `Gemfile` and run `bundle install`.
 
 > **Note:** This client has been developed for the [Elastic Site Search](https://www.elastic.co/products/site-search/service) API endpoints only.
 

--- a/lib/elastic/site-search/sso.rb
+++ b/lib/elastic/site-search/sso.rb
@@ -1,4 +1,4 @@
-require 'digest/sha1'
+require 'digest/sha2'
 
 module Elastic
   module SiteSearch
@@ -15,7 +15,7 @@ module Elastic
       end
 
       def self.token(user_id, timestamp)
-        Digest::SHA1.hexdigest("#{user_id}:#{Elastic::SiteSearch.platform_client_secret}:#{timestamp}")
+        Digest::SHA256.hexdigest("#{user_id}:#{Elastic::SiteSearch.platform_client_secret}:#{timestamp}")
       end
     end
   end

--- a/lib/elastic/site-search/version.rb
+++ b/lib/elastic/site-search/version.rb
@@ -1,5 +1,5 @@
 module Elastic
   module SiteSearch
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end

--- a/spec/sso_spec.rb
+++ b/spec/sso_spec.rb
@@ -11,14 +11,14 @@ describe Elastic::SiteSearch::SSO do
   end
 
   context '.token' do
-    it 'generates an SSO token' do
-      expect(Elastic::SiteSearch::SSO.token(user_id, timestamp)).to eq('81033d182ad51f231cc9cda9fb24f2298a411437')
+    it 'generates a proper SHA256 SSO token' do
+      expect(Elastic::SiteSearch::SSO.token(user_id, timestamp)).to eq('3da93f6d82efc8530614966ab847fd6d0b6d158ef02e4e65a8f731e299c28d86')
     end
   end
 
   context '.url' do
     it 'generates an SSO URL' do
-      expect(Elastic::SiteSearch::SSO.url(user_id)).to eq('https://swiftype.com/sso?user_id=5064a7de2ed960e715000276&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9&timestamp=1379382520&token=81033d182ad51f231cc9cda9fb24f2298a411437')
+      expect(Elastic::SiteSearch::SSO.url(user_id)).to eq('https://swiftype.com/sso?user_id=5064a7de2ed960e715000276&client_id=3e4fd842fc99aecb4dc50e5b88a186c1e206ddd516cdd336da3622c4afd7e2e9&timestamp=1379382520&token=3da93f6d82efc8530614966ab847fd6d0b6d158ef02e4e65a8f731e299c28d86')
     end
   end
 end


### PR DESCRIPTION
### Description
Currently, the `Site Search` product supports both `SHA-1` and `SHA-256` generated token for authentication.
For security reasons, it's required to start using `SHA-256` for new authentications.

This PR is dedicated to change `SHA-1` to `SHA-256` hashing algorithm